### PR TITLE
Add Food Critic options to .pronto.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+
+## 0.11.0
+
+### Changes
+
+* Add Foodcritic options rule_file, search_gems and include_rules, allows to customize CI with custom ignores and Foodcritic rules.
+* Add exclude option to ignore Foodcritic linter.
+
 ## 0.2.2
 
 ### Bugs fixed

--- a/README.md
+++ b/README.md
@@ -7,6 +7,27 @@
 
 Pronto runner for [Food Critic](https://github.com/acrmp/foodcritic), lint tool for chef. [What is Pronto?](https://github.com/mmozuras/pronto)
 
+## Configuration
+
+You can provide several Food Critic options via `.pronto.yml`:
+
+```yml
+foodcritic:
+  # Like CLI option --search-gems
+  search_gems: true
+
+  # Like CLI option --include, add custom rules to your CI
+  include_rules:
+    - lib/foodcritic/rules
+
+  # Like CLI option --rule-file
+  rule_file: .foodcritic-ci
+
+  # File GLOBs to ignore, matching files won't be passed to Food Critic
+  exclude:
+    - '**/test/integration/**/*_spec.rb'
+```
+
 ## Note
 
 Currently, naively uses path to determine if a file is a cookbook or a role configuration.

--- a/lib/pronto/foodcritic.rb
+++ b/lib/pronto/foodcritic.rb
@@ -7,11 +7,21 @@ module Pronto
       return [] if paths[:cookbook_paths].none? && paths[:role_paths].none?
 
       @linter = ::FoodCritic::Linter.new
-      @linter.check(paths).warnings.flat_map do |warning|
+      @linter.check(options).warnings.flat_map do |warning|
         ruby_patches.select { |patch| patch.new_file_full_path.to_s == warning.match[:filename] }
           .flat_map(&:added_lines)
           .select { |line| line.new_lineno == warning.match[:line] }
           .flat_map { |line| new_message(warning, line) }
+      end
+    end
+
+    def options
+      @options ||= begin
+        result = {}.merge(paths)
+        result[:rule_file] = foodcritic_rule_file if foodcritic_rule_file
+        result[:search_gems] = foodcritic_search_gems if foodcritic_search_gems
+        result[:include_rules] = Array(foodcritic_include_rules)
+        result
       end
     end
 
@@ -20,6 +30,7 @@ module Pronto
         result = { cookbook_paths: [], role_paths: [] }
         ruby_patches.each do |patch|
           path = patch.new_file_full_path.to_s
+          next if foodcritic_exclude.any? { |r| File.fnmatch(r, path) }
           if path.include?('cookbook')
             result[:cookbook_paths] << path
           elsif path.include?('role')
@@ -35,5 +46,26 @@ module Pronto
       message = "#{warning.rule.code} - #{warning.rule.name}"
       Message.new(path, line, :warning, message, nil, self.class)
     end
+
+    def pronto_foodcritic_config
+      @pronto_foodcritic_config ||= Pronto::ConfigFile.new.to_h['foodcritic'] || {}
+    end
+
+    def foodcritic_search_gems
+      pronto_foodcritic_config.fetch('search_gems', nil)
+    end
+
+    def foodcritic_rule_file
+      pronto_foodcritic_config.fetch('rule_file', nil)
+    end
+
+    def foodcritic_include_rules
+      pronto_foodcritic_config.fetch('include_rules', [])
+    end
+
+    def foodcritic_exclude
+      Array(pronto_foodcritic_config.fetch('exclude', []))
+    end
+
   end
 end

--- a/lib/pronto/foodcritic/version.rb
+++ b/lib/pronto/foodcritic/version.rb
@@ -1,5 +1,5 @@
 module Pronto
   module FoodCriticVersion
-    VERSION = '0.10.0'.freeze
+    VERSION = '0.11.0'.freeze
   end
 end


### PR DESCRIPTION
> Food Critic does not support configuration files. CIs usually configure it via CLI.
> Allow to customize Food Critic with additional rules, specify global rule file (useful for agreed ignores) and exclude certain files from linting.

Creating a fork in vinted org, as upstream does not have ability to release new gem versions https://github.com/prontolabs/pronto-foodcritic/pull/7

We''ll use fork in our CI in the mean time

@vinted/sre 